### PR TITLE
fix(contracts): reject risk scores above 100 in ERC-8126 registry

### DIFF
--- a/contracts/contracts/VerificationScoreRegistry.sol
+++ b/contracts/contracts/VerificationScoreRegistry.sol
@@ -50,6 +50,7 @@ contract VerificationScoreRegistry {
     error NotVerifier(address recovered, address expected);
     error AttestationTooOld(uint256 issuedAt, uint256 maxAge);
     error AttestationFromFuture(uint256 issuedAt);
+    error RiskScoreOutOfRange(uint8 score);
     error NonceUsed(uint256 nonce);
     error BadSignatureLength(uint256 length);
 
@@ -97,6 +98,10 @@ contract VerificationScoreRegistry {
         uint256 nonce,
         bytes calldata signature
     ) external {
+        // ERC-8126 defines a 0-100 risk scale. Scores above 100 must never be
+        // stored, even when signed by the verifier: downstream consumers treat
+        // 100 as the max-risk sentinel and would break on out-of-range values.
+        if (overallRiskScore > 100) revert RiskScoreOutOfRange(overallRiskScore);
         if (issuedAt > block.timestamp + 5 minutes) revert AttestationFromFuture(issuedAt);
         if (block.timestamp > issuedAt + maxAttestationAge) revert AttestationTooOld(issuedAt, maxAttestationAge);
         if (usedNonces[nonce] != 0) revert NonceUsed(nonce);

--- a/contracts/test/erc8126-registry.spec.ts
+++ b/contracts/test/erc8126-registry.spec.ts
@@ -121,4 +121,33 @@ describe("ERC-8126 VerificationScoreRegistry", () => {
       ctx.registry.submitAttestation(1, 5, ethers.ZeroHash, now + BigInt(3600), BigInt(2), future),
     ).to.be.revertedWithCustomError(ctx.registry, "AttestationFromFuture");
   });
+
+  it("rejects risk scores above the documented 0-100 scale and accepts 100", async () => {
+    const ctx = await deployFixture();
+    const now = BigInt(Math.floor(Date.now() / 1000));
+
+    for (const score of [101, 255]) {
+      const signature = await signAttestation(ctx, ctx.verifier, { score, issuedAt: now });
+      await expect(
+        ctx.registry.submitAttestation(1, score, ethers.ZeroHash, now, BigInt(score), signature),
+      ).to.be.revertedWithCustomError(ctx.registry, "RiskScoreOutOfRange");
+    }
+
+    // 100 is the documented max-risk sentinel and must remain storable.
+    const maxSignature = await signAttestation(ctx, ctx.verifier, {
+      score: 100,
+      issuedAt: now,
+      nonce: BigInt(999),
+      proofId: ethers.ZeroHash,
+    });
+    await (await ctx.registry.submitAttestation(
+      1,
+      100,
+      ethers.ZeroHash,
+      now,
+      BigInt(999),
+      maxSignature,
+    )).wait();
+    expect(await ctx.registry.getLatestRiskScore(1)).to.equal(100);
+  });
 });


### PR DESCRIPTION
Fixes #9.

## What

`VerificationScoreRegistry.submitAttestation()` accepted any `uint8` risk score (0–255), even though the registry documents 100 as the maximum and `getLatestRiskScore()` returns 100 as the unknown-agent max-risk sentinel. Scores above 100 could be stored and surfaced to dashboards/indexers or downstream ERC-8126 consumers that assume a 0–100 scale.

## Change

- Add `error RiskScoreOutOfRange(uint8 score)`.
- Reject `overallRiskScore > 100` at the top of `submitAttestation()`, before signature/nonce handling.
- Add tests: 101 and 255 revert with `RiskScoreOutOfRange`; 100 remains storable as the documented max-risk sentinel.

## Tests

`npm --prefix contracts run test` → **20 passing**.

Note: this fixes the source in the repository. The already-deployed registry instance on Base mainnet would need a redeploy/migration to inherit the check.